### PR TITLE
Add DataTableEditorExtension for extending the behavior of a DataTableEditor

### DIFF
--- a/Editor/DataDriven/DataTableEditor.cs
+++ b/Editor/DataDriven/DataTableEditor.cs
@@ -19,6 +19,16 @@ namespace Chris.DataDriven.Editor
         
         private const string NullType = "Null";
         
+        /// <summary>
+        /// Subscribe to add custom left toolbar
+        /// </summary>
+        public DrawToolBarDelegate OnDrawLeftTooBar;
+        
+        /// <summary>
+        /// Subscribe to add custom right toolbar
+        /// </summary>
+        public DrawToolBarDelegate OnDrawRightTooBar;
+        
         public DataTableRowView GetDataTableRowView()
         {
             _dataTableRowView ??= CreateDataTableRowView(Table);
@@ -139,7 +149,7 @@ namespace Chris.DataDriven.Editor
                     AssetDatabase.Refresh();
                 }
             }
-            DataTableEditorUtils.OnDrawLeftTooBar?.Invoke(this);
+            OnDrawLeftTooBar?.Invoke(this);
             GUILayout.FlexibleSpace();
 
             if (GUILayout.Button("Import from Json", DataTableEditorUtils.ToolBarButtonStyle))
@@ -155,7 +165,7 @@ namespace Chris.DataDriven.Editor
                     GUIUtility.ExitGUI();
                 }
             }
-            DataTableEditorUtils.OnDrawRightTooBar?.Invoke(this);
+            OnDrawRightTooBar?.Invoke(this);
             GUILayout.EndHorizontal();
         }
         

--- a/Editor/DataDriven/DataTableEditorExtension.cs
+++ b/Editor/DataDriven/DataTableEditorExtension.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Chris.DataDriven.Editor
+{
+    /// <summary>
+    /// Base class for extending the behavior of a DataTableEditor.
+    /// Override this class to inject custom initialization, toolbar drawing,
+    /// and cleanup logic for specific data tables.
+    /// </summary>
+    public abstract class DataTableEditorExtension: IDisposable
+    {
+        public virtual void Initialize(DataTableEditor editor)
+        {
+            
+        }
+        
+        public virtual void Dispose()
+        {
+            
+        }
+    }
+}

--- a/Editor/DataDriven/DataTableEditorExtension.cs.meta
+++ b/Editor/DataDriven/DataTableEditorExtension.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f6e17a27b93141edabaf99b0d9fd2f5e
+timeCreated: 1748272428

--- a/Editor/DataDriven/DataTableEditorUtils.cs
+++ b/Editor/DataDriven/DataTableEditorUtils.cs
@@ -37,16 +37,6 @@ namespace Chris.DataDriven.Editor
         public static DataTableUpdateDelegate OnDataTablePostUpdate;
         
         /// <summary>
-        /// Subscribe to add custom left toolbar
-        /// </summary>
-        public static DrawToolBarDelegate OnDrawLeftTooBar;
-        
-        /// <summary>
-        /// Subscribe to add custom right toolbar
-        /// </summary>
-        public static DrawToolBarDelegate OnDrawRightTooBar;
-        
-        /// <summary>
         /// Set row struct type
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/Editor/DataDriven/DataTableRowView.cs
+++ b/Editor/DataDriven/DataTableRowView.cs
@@ -53,7 +53,7 @@ namespace Chris.DataDriven.Editor
                     _selectIndex = -1;
                 }
                 _reorderableList.multiSelect = true;
-                _reorderableList.elementHeightCallback = (int index) =>
+                _reorderableList.elementHeightCallback = index =>
                 {
                     var prop = rowsProp.GetArrayElementAtIndex(index);
                     if (ReadOnly)
@@ -62,11 +62,11 @@ namespace Chris.DataDriven.Editor
                     }
                     return GetDataTableRowHeight(rowStructType, prop);
                 };
-                _reorderableList.drawHeaderCallback = (Rect rect) =>
+                _reorderableList.drawHeaderCallback = rect =>
                 {
                     DrawDataTableHeader(rect, header);
                 };
-                _reorderableList.drawElementCallback = (Rect rect, int index, bool selected, bool focused) =>
+                _reorderableList.drawElementCallback = (rect, index, selected, focused) =>
                 {
                     var prop = rowsProp.GetArrayElementAtIndex(index);
                     if (ReadOnly)


### PR DESCRIPTION
- Add `DataTableEditorExtension` for extending the behavior of a `DataTableEditor`.
- Remove static `DrawToolBarDelegate` in `DataTableEditorUtils`.